### PR TITLE
Enhanced image scraper/downloader

### DIFF
--- a/ImageRecipesChecker.py
+++ b/ImageRecipesChecker.py
@@ -1,0 +1,25 @@
+import os
+import json
+
+DEBUG = True
+
+if __name__ == '__main__':
+    recipes = sorted([os.path.join(os.getcwd(), "Recipes", recipie) for recipie in os.listdir("Recipes")])
+    null_images = 0
+    for recipe in recipes:
+        readable_name = recipe.split('/')[-1].replace(".json", "").replace("_", " ").capitalize()
+        if DEBUG:
+            print(f"Checking {readable_name}...", end="")
+        with open(recipe, "r") as recipe_file:
+            json_recipe = json.load(recipe_file)
+            image_does_not_exist = json_recipe["imageBase64"] is None
+            null_images += int(image_does_not_exist)
+
+            if DEBUG:
+                if image_does_not_exist:
+                    print("[MISSING]")
+                else:
+                    print("[OK!]")
+
+
+    print(f"Total missing images: {null_images} / {len(recipes)}")

--- a/main.py
+++ b/main.py
@@ -98,7 +98,7 @@ def downloadPage(linkToDownload):
     return soup
 
 def downloadAllRecipesFromGialloZafferano():
-    for pageNumber in tqdm(range(1,countTotalPages() + 1)):
+    for pageNumber in range(1,countTotalPages() + 1):
         linkList = 'https://www.giallozafferano.it/ricette-cat/page' + str(pageNumber)
         response = requests.get(linkList)
         soup= BeautifulSoup(response.text, 'html.parser')


### PR DESCRIPTION
This PR enhances the capabilities of the image scraper.
Previously, about a third of the recipes' images couldn't be downloaded as they had different class attributes or were placed in unexpected HTML tags (eg. <picture>).
This PR acts (mainly) on the `findImage` function, providing fallback logic if the image isn't found in the usual places, additionally, it adds a new file (`ImageRecipesChecker.py`) which tests if all of the downloaded recipes have an image.

Some other misc changes: 
Changed output file format to `json`
Changed output file name to not have spaces and being all in lower case