### PR TITLE
fix for missing list item in tag

### DIFF
--- a/main.py
+++ b/main.py
@@ -69,7 +69,10 @@ def findDescription(soup):
 
 def findCategory(soup):
     for tag in soup.find_all(attrs={"class": "gz-breadcrumb"}):
-        category = tag.li.a.string
+        try:
+            category = tag.li.a.string
+        except AttributeError:
+            category = 'Unknown'
         return category
 
 


### PR DESCRIPTION
Current code fails (the first time) for recipe "fumetto di pesce" on current page 143 in pagination - this is because of a missing tag element. Adding try/except logic which imputes a "Unknown" category string in that case.